### PR TITLE
Fix for usage

### DIFF
--- a/src/EtsyService.php
+++ b/src/EtsyService.php
@@ -7,6 +7,7 @@ use Gentor\OAuth1Etsy\Client\Server\Etsy;
 use League\OAuth1\Client\Credentials\TokenCredentials;
 use Illuminate\Session\SessionManager;
 use Illuminate\Session\Store;
+use Illuminate\Foundation\Application;
 
 /**
  * Class EtsyService
@@ -25,12 +26,12 @@ class EtsyService
 
     /**
      * EtsyService constructor.
-     * @param SessionManager $session
+     * @param \Illuminate\Foundation\Application $app
      * @param array $config
      */
-    public function __construct(SessionManager $session, array $config)
+    public function __construct(Application $app, array $config)
     {
-        $this->session = $session;
+        $this->session = new SessionManager($app);
 
         $this->server = new Etsy([
             'identifier' => $config['consumer_key'],

--- a/src/Providers/EtsyServiceProvider.php
+++ b/src/Providers/EtsyServiceProvider.php
@@ -26,7 +26,7 @@ class EtsyServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->bind('etsy', function ($app) {
-            return new EtsyService($app['config']['etsy']);
+            return new EtsyService($app, $app['config']['etsy']);
         });
     }
 


### PR DESCRIPTION
When trying to use this package I was getting the following error;

```
Type error: Argument 1 passed to Gentor\Etsy\EtsyService::__construct() must be an instance of Illuminate\Session\SessionManager, array given
```

Because the config (an array) was being passed to EtsyService.

The changes in this PR pass through the application where a new instance of a SessionManage is then created from that resolving this issue.